### PR TITLE
Add support for session and clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,6 @@ flask-boto3 uses several keys from a Flask configuration objects to customize it
 
 - `BOTO3_ACCESS_KEY` & `BOTO3_SECRET_KEY` : holds the AWS credentials, if `None` the extension will rely on `boto3`'s default credentials lookup.
 - `BOTO3_REGION` : holds the region that will be used for all connectors.
+- `BOTO3_PROFILE` : holds the AWS profile.
 - `BOTO3_SERVICES` : holds, as a list, the name of the AWS resources you want to use (e.g. `['sqs', 's3']`).
 - `BOTO3_OPTIONAL_PARAMS` : useful when you need to pass additional parameters to the connectors (e.g. for testing purposes), the format is a `dict` where the top-level keys are the name of the services you're using and for each the value is a `dict` containing to keys `args` (contains the parameters as `tuple`) and `kwargs` (contains the parameters as a `dict` when they should be passed as keyword arguments).

--- a/flask_boto3.py
+++ b/flask_boto3.py
@@ -29,12 +29,13 @@ class Boto3(object):
         )
 
         region = current_app.config.get('BOTO3_REGION')
-        sess = boto3.session.Session(
-            aws_access_key_id=current_app.config.get('BOTO3_ACCESS_KEY'),
-            aws_secret_access_key=current_app.config.get('BOTO3_SECRET_KEY'),
-            profile_name=current_app.config.get('BOTO3_PROFILE'),
-            region_name=region
-        )
+        sess_params = {
+            'aws_access_key_id': current_app.config.get('BOTO3_ACCESS_KEY'),
+            'aws_secret_access_key': current_app.config.get('BOTO3_SECRET_KEY'),
+            'profile_name': current_app.config.get('BOTO3_PROFILE'),
+            'region_name': region
+        }
+        sess = boto3.session.Session(**sess_params)
 
         try:
             cns = {}
@@ -44,6 +45,7 @@ class Boto3(object):
                     'BOTO3_OPTIONAL_PARAMS', {}
                 ).get(svc, {})
                 kwargs = params.get('kwargs', {})
+                kwargs.update(sess_params)
 
                 args = params.get('args', [region] if region else [])
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,8 +7,8 @@ from flask import _app_ctx_stack as stack
 from flask.ext.boto3 import Boto3
 
 
-@patch('boto3.resource')
-class TestFlaskBoto3(TestCase):
+@patch('boto3.session.Session.resource')
+class TestFlaskBoto3Resources(TestCase):
 
     def setUp(self):
         self.app = Flask('unit_tests')
@@ -38,20 +38,25 @@ class TestFlaskBoto3(TestCase):
         self.app.config['BOTO3_SERVICES'] = ['s3']
         self.app.config['BOTO3_ACCESS_KEY'] = 'access'
         self.app.config['BOTO3_SECRET_KEY'] = 'secret'
+        self.app.config['BOTO3_PROFILE'] = 'default'
         b = Boto3(self.app)
         with self.app.app_context():
             b.connections
+            region = 'eu-west-1'
             mock_resource.assert_called_once_with(
                 's3',
-                'eu-west-1',
+                region,
                 aws_access_key_id='access',
-                aws_secret_access_key='secret'
+                aws_secret_access_key='secret',
+                profile_name='default',
+                region_name=region
             )
 
     def test_004_pass_optional_params_through_conf(self, mock_resource):
         self.app.config['BOTO3_SERVICES'] = ['dynamodb']
         self.app.config['BOTO3_ACCESS_KEY'] = 'access'
         self.app.config['BOTO3_SECRET_KEY'] = 'secret'
+        self.app.config['BOTO3_PROFILE'] = 'default'
         self.app.config['BOTO3_OPTIONAL_PARAMS'] = {
             'dynamodb': {
                 'args': ('eu-west-1'),
@@ -63,11 +68,14 @@ class TestFlaskBoto3(TestCase):
         b = Boto3(self.app)
         with self.app.app_context():
             b.connections
+            region = 'eu-west-1'
             mock_resource.assert_called_once_with(
                 'dynamodb',
-                'eu-west-1',
+                region,
                 aws_access_key_id='access',
                 aws_secret_access_key='secret',
+                profile_name='default',
+                region_name=region,
                 fake_param='fake_value'
             )
 
@@ -81,6 +89,95 @@ class TestFlaskBoto3(TestCase):
 
     def test_006_check_boto_resources_are_available(self, mock_resource):
         self.app.config['BOTO3_SERVICES'] = ['s3', 'sqs']
+        b = Boto3(self.app)
+        with self.app.app_context():
+            resources = b.resources
+            eq_(len(resources), len(self.app.config['BOTO3_SERVICES']))
+            print(resources)
+
+
+@patch('boto3.session.Session.client')
+class TestFlaskBoto3Clients(TestCase):
+
+    def setUp(self):
+        self.app = Flask('unit_tests')
+        self.app.config['BOTO3_REGION'] = 'eu-west-1'
+
+    def test_001_populate_application_context(self, mock_resource):
+        self.app.config['BOTO3_SERVICES'] = ['codebuild', 'codedeploy']
+        b = Boto3(self.app)
+        with self.app.app_context():
+            assert_is_instance(b.connections, dict)
+            eq_(len(b.connections), 2)
+            assert_is_instance(stack.top.boto3_cns, dict)
+            eq_(len(stack.top.boto3_cns), 2)
+
+    def test_002_instantiate_connectors(self, mock_resource):
+        self.app.config['BOTO3_SERVICES'] = ['codebuild', 'codedeploy']
+        b = Boto3(self.app)
+        with self.app.app_context():
+            b.connections
+            eq_(mock_resource.call_count, 2)
+            assert_list_equal(
+                sorted([i[0][0] for i in mock_resource.call_args_list]),
+                sorted(self.app.config['BOTO3_SERVICES'])
+            )
+
+    def test_003_pass_credentials_through_app_conf(self, mock_resource):
+        self.app.config['BOTO3_SERVICES'] = ['codepipeline']
+        self.app.config['BOTO3_ACCESS_KEY'] = 'access'
+        self.app.config['BOTO3_SECRET_KEY'] = 'secret'
+        self.app.config['BOTO3_PROFILE'] = 'default'
+        b = Boto3(self.app)
+        with self.app.app_context():
+            b.connections
+            region = 'eu-west-1'
+            mock_resource.assert_called_once_with(
+                'codepipeline',
+                region,
+                aws_access_key_id='access',
+                aws_secret_access_key='secret',
+                profile_name='default',
+                region_name=region
+            )
+
+    def test_004_pass_optional_params_through_conf(self, mock_resource):
+        self.app.config['BOTO3_SERVICES'] = ['codepipeline']
+        self.app.config['BOTO3_ACCESS_KEY'] = 'access'
+        self.app.config['BOTO3_SECRET_KEY'] = 'secret'
+        self.app.config['BOTO3_PROFILE'] = 'default'
+        self.app.config['BOTO3_OPTIONAL_PARAMS'] = {
+            'codepipeline': {
+                'args': ('eu-west-1'),
+                'kwargs': {
+                    'fake_param': 'fake_value'
+                }
+            }
+        }
+        b = Boto3(self.app)
+        with self.app.app_context():
+            b.connections
+            region = 'eu-west-1'
+            mock_resource.assert_called_once_with(
+                'codepipeline',
+                region,
+                aws_access_key_id='access',
+                aws_secret_access_key='secret',
+                profile_name='default',
+                region_name=region,
+                fake_param='fake_value'
+            )
+
+    def test_005_check_boto_clients_are_available(self, mock_resource):
+        self.app.config['BOTO3_SERVICES'] = ['codedeploy', 'codebuild']
+        b = Boto3(self.app)
+        with self.app.app_context():
+            clients = b.clients
+            eq_(len(clients), len(self.app.config['BOTO3_SERVICES']))
+            print(clients)
+
+    def test_006_check_boto_resources_are_available(self, mock_resource):
+        self.app.config['BOTO3_SERVICES'] = ['codedeploy', 'codebuild']
         b = Boto3(self.app)
         with self.app.app_context():
             resources = b.resources

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -103,7 +103,7 @@ class TestFlaskBoto3Clients(TestCase):
         self.app = Flask('unit_tests')
         self.app.config['BOTO3_REGION'] = 'eu-west-1'
 
-    def test_001_populate_application_context(self, mock_resource):
+    def test_001_populate_application_context(self, mock_client):
         self.app.config['BOTO3_SERVICES'] = ['codebuild', 'codedeploy']
         b = Boto3(self.app)
         with self.app.app_context():
@@ -112,18 +112,18 @@ class TestFlaskBoto3Clients(TestCase):
             assert_is_instance(stack.top.boto3_cns, dict)
             eq_(len(stack.top.boto3_cns), 2)
 
-    def test_002_instantiate_connectors(self, mock_resource):
+    def test_002_instantiate_connectors(self, mock_client):
         self.app.config['BOTO3_SERVICES'] = ['codebuild', 'codedeploy']
         b = Boto3(self.app)
         with self.app.app_context():
             b.connections
-            eq_(mock_resource.call_count, 2)
+            eq_(mock_client.call_count, 2)
             assert_list_equal(
-                sorted([i[0][0] for i in mock_resource.call_args_list]),
+                sorted([i[0][0] for i in mock_client.call_args_list]),
                 sorted(self.app.config['BOTO3_SERVICES'])
             )
 
-    def test_003_pass_credentials_through_app_conf(self, mock_resource):
+    def test_003_pass_credentials_through_app_conf(self, mock_client):
         self.app.config['BOTO3_SERVICES'] = ['codepipeline']
         self.app.config['BOTO3_ACCESS_KEY'] = 'access'
         self.app.config['BOTO3_SECRET_KEY'] = 'secret'
@@ -132,7 +132,7 @@ class TestFlaskBoto3Clients(TestCase):
         with self.app.app_context():
             b.connections
             region = 'eu-west-1'
-            mock_resource.assert_called_once_with(
+            mock_client.assert_called_once_with(
                 'codepipeline',
                 region,
                 aws_access_key_id='access',
@@ -141,7 +141,7 @@ class TestFlaskBoto3Clients(TestCase):
                 region_name=region
             )
 
-    def test_004_pass_optional_params_through_conf(self, mock_resource):
+    def test_004_pass_optional_params_through_conf(self, mock_client):
         self.app.config['BOTO3_SERVICES'] = ['codepipeline']
         self.app.config['BOTO3_ACCESS_KEY'] = 'access'
         self.app.config['BOTO3_SECRET_KEY'] = 'secret'
@@ -158,7 +158,7 @@ class TestFlaskBoto3Clients(TestCase):
         with self.app.app_context():
             b.connections
             region = 'eu-west-1'
-            mock_resource.assert_called_once_with(
+            mock_client.assert_called_once_with(
                 'codepipeline',
                 region,
                 aws_access_key_id='access',
@@ -168,7 +168,7 @@ class TestFlaskBoto3Clients(TestCase):
                 fake_param='fake_value'
             )
 
-    def test_005_check_boto_clients_are_available(self, mock_resource):
+    def test_005_check_boto_clients_are_available(self, mock_client):
         self.app.config['BOTO3_SERVICES'] = ['codedeploy', 'codebuild']
         b = Boto3(self.app)
         with self.app.app_context():
@@ -176,7 +176,7 @@ class TestFlaskBoto3Clients(TestCase):
             eq_(len(clients), len(self.app.config['BOTO3_SERVICES']))
             print(clients)
 
-    def test_006_check_boto_resources_are_available(self, mock_resource):
+    def test_006_check_boto_resources_are_available(self, mock_client):
         self.app.config['BOTO3_SERVICES'] = ['codedeploy', 'codebuild']
         b = Boto3(self.app)
         with self.app.app_context():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from unittest import TestCase
 from mock import patch
 from nose.tools import assert_is_instance, assert_list_equal, eq_
@@ -7,12 +9,23 @@ from flask import _app_ctx_stack as stack
 from flask.ext.boto3 import Boto3
 
 
+def create_aws_mock_config():
+    aws_dir = os.path.expanduser('~/.aws')
+    aws_config = aws_dir + '/config'
+    if not os.path.exists(aws_dir):
+        os.makedirs(aws_dir)
+    if not os.path.isfile(aws_config):
+        with open(aws_config, 'w') as f:
+            f.write('[default]')
+
+
 @patch('boto3.session.Session.resource')
 class TestFlaskBoto3Resources(TestCase):
 
     def setUp(self):
         self.app = Flask('unit_tests')
         self.app.config['BOTO3_REGION'] = 'eu-west-1'
+        create_aws_mock_config()
 
     def test_001_populate_application_context(self, mock_resource):
         self.app.config['BOTO3_SERVICES'] = ['s3', 'sqs']
@@ -102,6 +115,7 @@ class TestFlaskBoto3Clients(TestCase):
     def setUp(self):
         self.app = Flask('unit_tests')
         self.app.config['BOTO3_REGION'] = 'eu-west-1'
+        create_aws_mock_config()
 
     def test_001_populate_application_context(self, mock_client):
         self.app.config['BOTO3_SERVICES'] = ['codebuild', 'codedeploy']


### PR DESCRIPTION
@Ketouem thanks for creating flask-boto3. It's great.

This PR adds support for boto3 sessions and clients. Not all AWS services are supported as resources via boto.

I was trying to use flask-boto3 to connect to codedeploy and codebuild for my app and was getting the following:
```bash
boto3.exceptions.ResourceNotExistsError: The 'codedeploy' resource does not exist.
The available resources are:
   - cloudformation
   - cloudwatch
   - dynamodb
   - ec2
   - glacier
   - iam
   - opsworks
   - s3
   - sns
   - sqs

Consider using a boto3.client('codedeploy') instead of a resource for 'codedeploy'
```

The proposed changes address this issue.