### PR TITLE
Fix how args and kwargs are passed to boto client() and resource()

### DIFF
--- a/flask_boto3.py
+++ b/flask_boto3.py
@@ -44,10 +44,17 @@ class Boto3(object):
                 params = current_app.config.get(
                     'BOTO3_OPTIONAL_PARAMS', {}
                 ).get(svc, {})
-                kwargs = params.get('kwargs', {})
-                kwargs.update(sess_params)
 
-                args = params.get('args', [region] if region else [])
+                # Get session params and overritde them with kwargs
+                # `profile_name` cannot be passed to clients and resources
+                kwargs = sess_params.copy()
+                kwargs.update(params.get('kwargs', {}))
+                del kwargs['profile_name']
+
+                # Overritde the region if one is defined as an argument
+                args = params.get('args', [])
+                if len(args) >= 1:
+                    del kwargs['region_name']
 
                 if not(isinstance(args, list) or isinstance(args, tuple)):
                     args = [args]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -55,14 +55,11 @@ class TestFlaskBoto3Resources(TestCase):
         b = Boto3(self.app)
         with self.app.app_context():
             b.connections
-            region = 'eu-west-1'
             mock_resource.assert_called_once_with(
                 's3',
-                region,
                 aws_access_key_id='access',
                 aws_secret_access_key='secret',
-                profile_name='default',
-                region_name=region
+                region_name='eu-west-1'
             )
 
     def test_004_pass_optional_params_through_conf(self, mock_resource):
@@ -81,14 +78,11 @@ class TestFlaskBoto3Resources(TestCase):
         b = Boto3(self.app)
         with self.app.app_context():
             b.connections
-            region = 'eu-west-1'
             mock_resource.assert_called_once_with(
                 'dynamodb',
-                region,
+                'eu-west-1',
                 aws_access_key_id='access',
                 aws_secret_access_key='secret',
-                profile_name='default',
-                region_name=region,
                 fake_param='fake_value'
             )
 
@@ -145,14 +139,11 @@ class TestFlaskBoto3Clients(TestCase):
         b = Boto3(self.app)
         with self.app.app_context():
             b.connections
-            region = 'eu-west-1'
             mock_client.assert_called_once_with(
                 'codepipeline',
-                region,
                 aws_access_key_id='access',
                 aws_secret_access_key='secret',
-                profile_name='default',
-                region_name=region
+                region_name='eu-west-1'
             )
 
     def test_004_pass_optional_params_through_conf(self, mock_client):
@@ -171,14 +162,11 @@ class TestFlaskBoto3Clients(TestCase):
         b = Boto3(self.app)
         with self.app.app_context():
             b.connections
-            region = 'eu-west-1'
             mock_client.assert_called_once_with(
                 'codepipeline',
-                region,
+                'eu-west-1',
                 aws_access_key_id='access',
                 aws_secret_access_key='secret',
-                profile_name='default',
-                region_name=region,
                 fake_param='fake_value'
             )
 


### PR DESCRIPTION
Unfortunately, my previous PR broke things quite a bit. Boto3 resource() and client() don't accept `profile_name` as an argument. I was accidentally passing it via BOTO3_OPTIONAL_PARAMS. This was causing the errors:
```bash
TypeError: client() got an unexpected keyword argument 'profile_name'
TypeError: resource() got an unexpected keyword argument 'profile_name'
```

There was also an error if you pass the region via BOTO3_OPTIONAL_PARAMS args.

The issues are fixed in this PR. `BOTO3_PROFILE` is used only for creating the boto3 session as I originally intended. 